### PR TITLE
Implementation of TBufferedStream using a circular buffer.

### DIFF
--- a/src/TBufferedStream.cpp
+++ b/src/TBufferedStream.cpp
@@ -4,49 +4,150 @@
 #include <iostream>
 #include <string.h>
 
-TBufferedStream::TBufferedStream(TStream &readBuffer, unsigned int nBytes) : TStream(readBuffer.fFromVersion), fBuf(NULL, 0), fIn(&fBuf) {
-    fCharBuf = new char[nBytes];
-    ReadFromStream(readBuffer, fCharBuf, nBytes);
-    fBuf.reinit(fCharBuf, nBytes);
-    fIn.clear();
+//TBufferedStream::TBufferedStream() : TStream(0), fSize(0) {
+//    nAllocatedBytes = 10;
+//    fBuffer = new char[nAllocatedBytes];
+//    fFirst = fBuffer;
+//    fSize = 0;
+//    fLast = fBuffer - 1 + fSize;
+//}
+
+TBufferedStream::TBufferedStream(TStream &readBuffer, const size_t &nBytes) : TStream(readBuffer.fFromVersion) {
+    nAllocatedBytes = nBytes + SIZE_INCREMENT;
+    fBuffer = new char[nAllocatedBytes];
+    fFirst = fBuffer;
+    readBuffer.Read(fBuffer, nBytes);
+    fSize = nBytes;
+    fLast = fBuffer - 1 + fSize;
 }
 
-TBufferedStream::TBufferedStream(const TBufferedStream &other) : TStream(other), fBuf(NULL,0), fIn(&fBuf) {
+TBufferedStream::TBufferedStream(const TBufferedStream &other) : TStream(other), fBuffer(NULL) {
     *this = other;
 }
 
-TBufferedStream &TBufferedStream::operator= (const TBufferedStream &other) {
-    unsigned int nBytes = other.fBuf.size();
-    fCharBuf = new char[nBytes];
-    memcpy(fCharBuf, other.fCharBuf, nBytes);
-    fBuf.reinit(fCharBuf, nBytes);
-    fOut.str(other.fOut.str());
+TBufferedStream &TBufferedStream::operator=(const TBufferedStream &other) {
+    nAllocatedBytes = other.nAllocatedBytes;
+    if (fBuffer) delete[] fBuffer;
+    fBuffer = new char[nAllocatedBytes];
+    memcpy(fBuffer, other.fBuffer, other.fSize);
+    fSize = other.fSize;
+    fFirst = fBuffer;
+    fLast = fBuffer - 1 + fSize;
     return *this;
 }
 
 TBufferedStream::~TBufferedStream() {
-    delete []fCharBuf;
+    delete []fBuffer;
 }
 
-void TBufferedStream::TransferBuffers() {
-    if (fBuf.showmanyc()) { // transfering without consuming the buffer
-        throw std::runtime_error(
-            "TBufferedStream: I still have data to be read before transfer!");
-    }
-    delete[] fCharBuf;
-    unsigned int nBytes = fOut.tellp();
-    fCharBuf = new char[nBytes];
-    memcpy(fCharBuf, fOut.str().c_str(), nBytes);
-    fBuf.reinit(fCharBuf, nBytes);
-    fOut.str("");
-}
-
-TBufferedStream &TBufferedStream::operator<< (const TBufferedStream &other) {
-    const unsigned int nBytesOther = other.fBuf.size();
-    fOut.write(other.fCharBuf, nBytesOther);
-
+TBufferedStream &TBufferedStream::operator<<(TBufferedStream &other) {
+    const unsigned int nBytesOther = other.fSize;
+    char temp[nBytesOther];
+    other.Read(temp, nBytesOther);
+    Write(temp, nBytesOther);
     return *this;
 }
 
-std::istream &TBufferedStream::GetReadStream() { return fIn; }
-std::ostream &TBufferedStream::GetWriteStream() { return fOut; }
+TBufferedStream &TBufferedStream::operator<<(const TBufferedStream &other) {
+    const unsigned int nBytesOther = other.fSize;
+    char temp[nBytesOther];
+    other.ConstRead(temp, nBytesOther);
+    Write(temp, nBytesOther);
+    return *this;
+}
+
+void TBufferedStream::Read(char *dest, const size_t &nBytes) {
+    if (nBytes > fSize) {
+        std::string msg("TBufferedStream: Cannot read ");
+        msg.append(std::to_string(nBytes));
+        msg.append(" bytes; there are only ");
+        msg.append(std::to_string(fSize));
+        msg.append(" available.");
+        throw std::runtime_error(msg);
+    }
+    char *endBuffer = fBuffer + nAllocatedBytes;
+
+    if (fFirst + nBytes < endBuffer) {
+        // direct reading (we do not need to cycle to the beginning of the buffer to read)
+        memcpy(dest, fFirst, nBytes);
+        fFirst += nBytes;
+    } else {
+        // we need to read past the end of the buffer. 
+        const size_t nBytesRead(endBuffer - fFirst);
+        memcpy(dest, fFirst, nBytesRead);
+        if (nBytes != nBytesRead) {
+            memcpy(dest + nBytesRead, fBuffer, nBytes - nBytesRead);
+        }
+        fFirst = fBuffer + nBytes - nBytesRead;
+    }
+
+    fSize -= nBytes;
+}
+
+void TBufferedStream::ConstRead(char *dest, const size_t &nBytes) const {
+    if (nBytes > fSize) {
+        std::string msg("TBufferedStream: Cannot read ");
+        msg.append(std::to_string(nBytes));
+        msg.append(" bytes; there are only ");
+        msg.append(std::to_string(fSize));
+        msg.append(" available.");
+        throw std::runtime_error(msg);
+    }
+    char *endBuffer = fBuffer + nAllocatedBytes;
+
+    if (fFirst + nBytes < endBuffer) {
+        // direct reading (we do not need to cycle to the beginning of the buffer to read)
+        memcpy(dest, fFirst, nBytes);
+    } else {
+        // we need to read past the end of the buffer. 
+        const size_t nBytesRead(endBuffer - fFirst);
+        memcpy(dest, fFirst, nBytesRead);
+        if (nBytes != nBytesRead) {
+            memcpy(dest + nBytesRead, fBuffer, nBytes - nBytesRead);
+        }
+    }
+}
+
+void TBufferedStream::Write(const char *source, const size_t &nBytes) {
+    if (fSize + nBytes > nAllocatedBytes) {
+        size_t oldSize = fSize;
+        size_t newAllocatedBytes = oldSize + nBytes + SIZE_INCREMENT;
+        char *temp = new char[newAllocatedBytes];
+        ConstRead(temp, oldSize);
+        memcpy(temp + oldSize, source, nBytes);
+        delete[] fBuffer;
+        fBuffer = temp;
+        nAllocatedBytes = newAllocatedBytes;
+        fFirst = fBuffer;
+        fSize = oldSize + nBytes;
+        fLast = fBuffer - 1 + fSize;
+    } else {
+        char *endBuffer = fBuffer + nAllocatedBytes;
+
+        if (fLast + nBytes < endBuffer) {
+            // direct writing (we do not need to cycle to the beginning of the buffer to write)
+            memcpy(fLast + 1, source, nBytes);
+            fLast += nBytes;
+        } else {
+            // we need to write past the end of the buffer. 
+            const size_t nBytesWritten(endBuffer - fLast - 1);
+            memcpy(fLast + 1, source, nBytesWritten);
+            if (nBytes != nBytesWritten) {
+                memcpy(fBuffer, source + nBytesWritten, nBytes - nBytesWritten);
+            }
+            fLast = fBuffer - 1 + nBytes - nBytesWritten;
+        }
+
+        fSize += nBytes;
+    }
+}
+
+void TBufferedStream::Print(){
+    std::cout << "fSize=" << fSize << std::endl;
+    double temp[fSize/8];
+    ConstRead(reinterpret_cast<char*>(temp), fSize);
+    for (unsigned int i = 0; i < fSize/8; ++i) {
+        std::cout << temp[i] << " ";
+    }
+    std::cout << std::endl;
+}

--- a/src/TBufferedStream.h
+++ b/src/TBufferedStream.h
@@ -5,20 +5,26 @@
 
 class TBufferedStream : public TStream {
 public:
-    TBufferedStream(TStream &readBuffer, unsigned int nBytes);
+    //TBufferedStream();
+    TBufferedStream(TStream &readBuffer, const size_t &nBytes);
     TBufferedStream(const TBufferedStream &readBuffer);
     ~TBufferedStream();
     TBufferedStream &operator= (const TBufferedStream &);
-    void TransferBuffers();
+    virtual TBufferedStream &operator<< (TBufferedStream &other);
     virtual TBufferedStream &operator<< (const TBufferedStream &other);
     using TStream::operator<<;
+    void Print();
 protected:
-    virtual std::istream &GetReadStream();
-    virtual std::ostream &GetWriteStream();
+    virtual void Read(char *dest, const size_t &nBytes);
+    virtual void ConstRead(char *dest, const size_t &nBytes) const;
+    virtual void Write(const char *source, const size_t &nBytes);
 private:
-    std::istream fIn;
-    std::ostringstream fOut;
-    char *fCharBuf;
-    TMemBuf fBuf;
+    char *fBuffer;
+    char *fFirst;
+    char *fLast;
+    size_t nAllocatedBytes;
+    size_t fSize;
+    
+    static const size_t SIZE_INCREMENT = size_t(1);
 };
 #endif // TBUFFEREDSTREAM_H

--- a/src/TFileStream.cpp
+++ b/src/TFileStream.cpp
@@ -60,9 +60,16 @@ void TFileStream::CloseWrite() {
     }
 }
 
-std::istream &TFileStream::GetReadStream() {
-    return fIn;
+void TFileStream::Read(char * dest, const size_t &nBytes){
+    fIn.read(dest, nBytes);
+    if (fIn.bad()){
+        throw std::runtime_error("TFileStream:Could not read from stream");
+    }
 }
-std::ostream &TFileStream::GetWriteStream() {
-    return fOut;
+    
+void TFileStream::Write(const char *source, const size_t &nBytes){
+    fOut.write(source, nBytes);
+    if (fOut.bad()) {
+        throw std::runtime_error("TFileStream:Could not write to stream");
+    }
 }

--- a/src/TFileStream.h
+++ b/src/TFileStream.h
@@ -16,8 +16,8 @@ class TFileStream : public TStream {
     void CloseWrite();
 
   protected:
-    virtual std::istream &GetReadStream();
-    virtual std::ostream &GetWriteStream();
+    virtual void Read(char *dest, const size_t &nBytes);
+    virtual void Write(const char *source, const size_t &nBytes);
 
   private:
     std::ifstream fIn;

--- a/src/TLineTranslator.h
+++ b/src/TLineTranslator.h
@@ -3,6 +3,7 @@
 #include "TBufferedStream.h"
 #include "TLine.h"
 #include "TPointTranslator.h"
+
 class TLineTranslator {
 public:
 
@@ -36,12 +37,12 @@ public:
 
             case 0: // TLine had changes in version 1
                 UpdateFromV0(buf); // returns v1 buffer
-                if (toVersion == buf.fFromVersion){
+                if (toVersion == buf.fFromVersion) {
                     break;
                 }
             case 1: // TLine had changes in version 2
                 UpdateFromV1(buf); // returns v2 buffer
-                if (toVersion == buf.fFromVersion){
+                if (toVersion == buf.fFromVersion) {
                     break;
                 }
             default:
@@ -84,8 +85,7 @@ public:
            its data structure.*/
         baseStream << TPointTranslator::UpdateStream(baseStream, toVersion);
         baseStream << TPointTranslator::UpdateStream(baseStream, toVersion);
-
-        baseStream.TransferBuffers();        
+        baseStream.fFromVersion = toVersion;
     }
 
     static void UpdateFromV0(TBufferedStream &stream) {
@@ -99,8 +99,7 @@ public:
         stream << aux2;
         stream >> aux1; // reads fYe
         stream << aux1;
-        
-        stream.TransferBuffers();
+
         stream.fFromVersion = 1;
         // must return fXb, fYb, fXe, fYe (all double variables)
     }

--- a/src/TPointTranslator.h
+++ b/src/TPointTranslator.h
@@ -4,24 +4,26 @@
 #include "TPoint.h"
 
 class TPointTranslator {
-  public:
+public:
+
     static TBufferedStream UpdateStream(TStream &baseStream,
-                                        const unsigned long toVersion) {
+            const unsigned long toVersion) {
         // reads N bytes (depending on stream.fFromVersion)
         TBufferedStream buf(baseStream, SizeOfClass(baseStream.fFromVersion));
         // TPoint didnt exist prior to version 2
         if (baseStream.fFromVersion < 2) {
             throw std::runtime_error("TPointTranslator:Trying to read a TPoint "
-                                     "from a version prior to its creation");
+                    "from a version prior to its creation");
         }
 
         switch (baseStream.fFromVersion) {
-            UpdateFromV2(buf); // returns v3 buffer
-            if (toVersion == buf.fFromVersion) {
-                break;
-            }
-        default:
-            UpdateAttributes(buf, toVersion);
+            case 2:
+                UpdateFromV2(buf); // returns v3 buffer
+                if (toVersion == buf.fFromVersion) {
+                    break;
+                }
+            default:
+                UpdateAttributes(buf, toVersion);
         }
         return buf;
     }
@@ -30,32 +32,33 @@ class TPointTranslator {
         unsigned int totalSize = 0;
         if (versionNumber < 2) {
             throw std::runtime_error(
-                "TPointTranslator:Trying to calculate the size of a TPoint "
-                "from a version prior to its creation");
+                    "TPointTranslator:Trying to calculate the size of a TPoint "
+                    "from a version prior to its creation");
         }
         switch (versionNumber) {
-        case 2:
-            // stream << fX;
-            // stream << fY;
-            totalSize += 2 * sizeof(double);
-            break;
-        default: // 3 onwards
-            // stream << fX;
-            // stream << fY;
-            // stream << fZ;
-            totalSize += 3 * sizeof(double);
-            break;
+            case 2:
+                // stream << fX;
+                // stream << fY;
+                totalSize += 2 * sizeof (double);
+                break;
+            default: // 3 onwards
+                // stream << fX;
+                // stream << fY;
+                // stream << fZ;
+                totalSize += 3 * sizeof (double);
+                break;
         }
         return totalSize;
     }
 
-    static void UpdateAttributes(TBufferedStream & /*stream*/,
-                                 const unsigned long & /*toVersion*/) {
+    static void UpdateAttributes(TBufferedStream & stream,
+            const unsigned long & toVersion) {
         /*expects to read the attributes according to the most recent version
             of TLine. However, if any attribute is an object, its
            StreamTranslator will be called in order to account for changes in
            its data structure. Up to V3, this method will do nothing, since the
            attributes are all of the primitive type double*/
+        stream.fFromVersion = toVersion;
     }
 
     static void UpdateFromV2(TBufferedStream &stream) {
@@ -67,13 +70,12 @@ class TPointTranslator {
         stream << aux;
         aux = 0.; // creates fZ default value
         stream << aux;
-        
-        stream.TransferBuffers();
+
         stream.fFromVersion = 3;
         // must return fX, fY and fZ(all double variables)
     }
 
-  private:
+private:
     TPointTranslator();
     ~TPointTranslator();
 };

--- a/src/TStream.cpp
+++ b/src/TStream.cpp
@@ -16,45 +16,11 @@ TStream::~TStream() {
 }
 
 TStream &TStream::operator>>(double &var) {
-    std::istream &in = GetReadStream();
-    in.read(reinterpret_cast<char *> (&var), sizeof (var));
-    if (in.bad()) {
-        throw std::runtime_error("TStream:Could not read from stream");
-    }
+    Read(reinterpret_cast<char *> (&var), sizeof (var));
     return *this;
 }
 
 TStream &TStream::operator<<(const double &var) {
-    std::ostream &out = GetWriteStream();
-    out.write(reinterpret_cast<const char *> (&var), sizeof (var));
-    if (out.bad()) {
-        throw std::runtime_error("TStream:Could not write to stream");
-    }
+    Write(reinterpret_cast<const char *> (&var), sizeof (var));
     return *this;
-}
-
-std::streamsize TStream::StreamSize(TStream *stream) {
-    std::istream &in = stream->GetReadStream();
-    // double w, x, y, z;
-    // in->read(reinterpret_cast<char *>(&w), sizeof(double));
-    // in->read(reinterpret_cast<char *>(&x), sizeof(double));
-    // in->read(reinterpret_cast<char *>(&y), sizeof(double));
-    // in->read(reinterpret_cast<char *>(&z), sizeof(double));
-    // std::cout << w << std::endl;
-    // std::cout << x << std::endl;
-    // std::cout << y << std::endl;
-    // std::cout << z << std::endl;
-    in.seekg(0, in.end);
-    int fsize = in.tellg(); //doesnt work
-    in.seekg(0, in.beg);
-    if (fsize == -1) {
-        throw std::runtime_error("TStream: Could not get stream size");
-    }
-    return fsize;
-}
-
-void TStream::ReadFromStream(TStream &stream, char * &dest,
-        const unsigned int &nBytes) {
-    std::istream &in = stream.GetReadStream();
-    in.read(dest, nBytes);
 }

--- a/src/TStream.h
+++ b/src/TStream.h
@@ -12,14 +12,11 @@ public:
     ~TStream();
     virtual TStream &operator>>(double &var);
     virtual TStream &operator<<(const double &var);
-    virtual std::streamsize StreamSize(TStream *stream);
+    virtual void Read(char *dest, const size_t &nBytes) = 0;
+    virtual void Write(const char *source, const size_t &nBytes) = 0;
+ 
     static const unsigned long fCurrentVersion = 3;
     unsigned long fFromVersion;
 
-protected:
-    void ReadFromStream(TStream &stream, char * &dest,
-            const unsigned int &nBytes);
-    virtual std::istream &GetReadStream() = 0;
-    virtual std::ostream &GetWriteStream() = 0;
 };
 #endif // TSTREAM_H

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,10 +1,11 @@
 #include "TLine.h"
 #include "TFileStream.h"
+#include "TBufferedStream.h"
 #include <iostream>
 #include <string>
 #include <string.h>
 
-int main(int argc, char *argv[]) {
+int main(int argc, char *argv[]) {    
     if (argc != 2 || strlen(argv[1]) != 1) {
         std::cout << "usage:" << argv[0] << " [0,1]"
                   << " - 0 for reading 1 for writing" << std::endl;


### PR DESCRIPTION
The implementation of TBufferedStream was changed to an elastic circular buffer. This simplifies the use of the buffered stream, as one isn't required to call TransferBuffers() anymore. Also, this change eliminates the use of both an input and an output buffer, joining all the logic in an input/output buffer.

Using this new version we could just use << and >> operators to write to and read from the buffer.

The drawback is that we become unable to detect that the user is reading a content that they had just written to the buffer in a translation operation. On the other hand, this implies that we are giving more responsibility to the user and more flexibility and simplicity to the buffer.

Maybe some documentation is still missing... This could be done later.

The value of SIZE_INCREMENT in a real-world scenario should be bigger. This was just a test.